### PR TITLE
Chore/python nightly node24

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -49,7 +49,7 @@ on:
 
 env:
   PYTHON_VERSION: '3.11'
-  NODE_VERSION: '18'
+  NODE_VERSION: '24'
 
 jobs:
   setup:

--- a/utils/error_handler.py
+++ b/utils/error_handler.py
@@ -11,7 +11,7 @@ Design principles:
 import logging
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ class ScreenshotService:
 
     def capture(self, driver, test_name, prefix="error"):
         """Capture screenshot. Returns path or None on failure."""
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
         path = self.screenshots_dir / f"{prefix}_{test_name}_{ts}.png"
         try:
             driver.save_screenshot(str(path))

--- a/utils/test_data_manager.py
+++ b/utils/test_data_manager.py
@@ -6,7 +6,7 @@ Supports JSON/YAML/CSV loading with environment-based configs.
 import csv
 import json
 import random
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import yaml  # type: ignore[import-untyped]
@@ -106,12 +106,12 @@ class DataManager:
 
     def save_test_results_yaml(self, results, filename=None):
         """Save test results in YAML format. Returns path."""
-        ts = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
+        ts = datetime.now(UTC).strftime("%Y%m%d_%H%M%S")
         path = self.data_dir / "results" / (filename or f"results_{ts}.yml")
         path.parent.mkdir(exist_ok=True)
         data = {
             "test_execution": {
-                "timestamp": datetime.now(timezone.utc).isoformat(),
+                "timestamp": datetime.now(UTC).isoformat(),
                 "total_tests": results.get("total_tests", 0),
                 "passed": results.get("passed", 0),
                 "failed": results.get("failed", 0),
@@ -157,7 +157,7 @@ class DataManager:
                 "timeout": random.randint(10, 20),
                 "expected_title_contains": random.choice(terms).split()[0],
                 "generated": True,
-                "created_at": datetime.now(timezone.utc).isoformat(),
+                "created_at": datetime.now(UTC).isoformat(),
             }
             for i in range(count)
         ]
@@ -166,16 +166,13 @@ class DataManager:
 
     def cleanup_old_results(self, days_to_keep=30):
         """Clean up result files older than specified days."""
-        cutoff = datetime.now(timezone.utc) - timedelta(days=days_to_keep)
+        cutoff = datetime.now(UTC) - timedelta(days=days_to_keep)
         results_dir = self.data_dir / "results"
         if not results_dir.exists():
             return
         for path in results_dir.rglob("*.json"):
             try:
-                if (
-                    datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
-                    < cutoff
-                ):
+                if datetime.fromtimestamp(path.stat().st_mtime, tz=UTC) < cutoff:
                     path.unlink()
             except (OSError, ValueError):
                 continue


### PR DESCRIPTION
## Description
<!-- What does this PR do? Link to the relevant task or issue. -->



## Type of change
- [ ] `feat` — new feature (test, page, component, locator)
- [ ] `fix` — bug fix
- [ ] `refactor` — architectural improvement
- [ ] `chore` — dependency update, tooling, CI
- [ ] `docs` — documentation only

---

## 7 Laws Compliance Checklist
> Every PR must satisfy all 7 laws. CI will fail if any is violated.
> Reference: [STANDARDS.md](../STANDARDS.md) · [ADRs](../docs/adr/)

- [ ] **Law 1 — Locator Mirroring:** every new/modified Page has a corresponding Locator file
- [ ] **Law 2 — No assertions in POMs:** `pages/`, `locators/`, `components/` contain zero `assert/expect/should`
- [ ] **Law 3 — No selectors in specs:** `tests/` / `e2e/` contain zero `By.`, `cy.get()`, `page.locator()`
- [ ] **Law 4 — Inheritance ≤ 1 level:** no inheritance chains deeper than `Page → BasePage`
- [ ] **Law 5 — Stateless POMs:** no mutable instance state added beyond `driver/page` and `locators`
- [ ] **Law 6 — Pure utils:** all new helpers in `utils/` are pure/stateless functions or classes
- [ ] **Law 7 — Identical naming:** class/file/method names match the canonical names in `TEST_PARITY.md`

---

## Parity Checklist
> Required for any PR that adds or modifies a test scenario.

- [ ] This PR does **not** add or modify test scenarios (parity check N/A)
- [ ] OR: This scenario exists in `TEST_PARITY.md` with a canonical ID and I have opened / linked PRs in all 5 repos

---

## Architectural Changes
> Required only if this PR changes a cross-cutting pattern (new layer, new tool, etc.)

- [ ] No architectural change
- [ ] OR: A new ADR has been authored / linked: `ADR-XXX` → <!-- link here -->

---

## Sync-Managed Files
> These files are managed by `sync-standards.sh`. Do not edit them directly in this repo.

- [ ] I did **not** modify any sync-managed file (STANDARDS.md, docs/adr/*, lefthook.yml, renovate.json, etc.)
- [ ] OR: I edited the canonical in `shared-docs/`, ran `sync-standards.sh`, and the updated files are included in this PR

---

## Testing
- [ ] `task test` passes locally
- [ ] `task lint` passes locally (0 warnings)
- [ ] `task audit` passes locally (0 violations)

---

## Screenshots / Evidence
<!-- If applicable: test run output, Allure report link, or before/after screenshot -->
